### PR TITLE
Update to Cardinal Components API V3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ org.gradle.jvmargs=-Xmx4G
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
 	fabric_version=0.20.2+build.402-1.16
-	cca_version=2.6.0
+	cca_version=2.7.1
 	reach_version=1.0.1
 	ffl_version=1.1.0
 	autoconfig_version=3.2.2

--- a/src/main/java/io/github/apace100/origins/Origins.java
+++ b/src/main/java/io/github/apace100/origins/Origins.java
@@ -37,7 +37,6 @@ public class Origins implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		LOGGER.info("Origins is initializing. Have fun!");
-		ModComponents.register();
 		ModBlocks.register();
 		ModItems.register();
 		ModTags.register();

--- a/src/main/java/io/github/apace100/origins/component/OriginComponent.java
+++ b/src/main/java/io/github/apace100/origins/component/OriginComponent.java
@@ -1,13 +1,13 @@
 package io.github.apace100.origins.component;
 
 import com.google.common.collect.Lists;
+import dev.onyxstudios.cca.api.v3.component.sync.AutoSyncedComponent;
 import io.github.apace100.origins.origin.Origin;
 import io.github.apace100.origins.origin.OriginLayer;
 import io.github.apace100.origins.power.Power;
 import io.github.apace100.origins.power.PowerType;
 import io.github.apace100.origins.power.ValueModifyingPower;
 import io.github.apace100.origins.registry.ModComponents;
-import nerdhub.cardinal.components.api.util.sync.EntitySyncedComponent;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.player.PlayerEntity;
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-public interface OriginComponent extends EntitySyncedComponent {
+public interface OriginComponent extends AutoSyncedComponent {
 
 	boolean hasOrigin(OriginLayer layer);
 	boolean hasAllOrigins();
@@ -35,8 +35,10 @@ public interface OriginComponent extends EntitySyncedComponent {
 
 	void setOrigin(OriginLayer layer, Origin origin);
 
+	void sync();
+
 	static void sync(PlayerEntity player) {
-		ModComponents.ORIGIN.get(player).sync();
+		ModComponents.ORIGIN.sync(player);
 	}
 
 	static <T extends Power> List<T> getPowers(Entity entity, Class<T> powerClass) {

--- a/src/main/java/io/github/apace100/origins/component/OriginComponent.java
+++ b/src/main/java/io/github/apace100/origins/component/OriginComponent.java
@@ -2,6 +2,7 @@ package io.github.apace100.origins.component;
 
 import com.google.common.collect.Lists;
 import dev.onyxstudios.cca.api.v3.component.sync.AutoSyncedComponent;
+import dev.onyxstudios.cca.api.v3.component.tick.ServerTickingComponent;
 import io.github.apace100.origins.origin.Origin;
 import io.github.apace100.origins.origin.OriginLayer;
 import io.github.apace100.origins.power.Power;
@@ -17,7 +18,7 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-public interface OriginComponent extends AutoSyncedComponent {
+public interface OriginComponent extends AutoSyncedComponent, ServerTickingComponent {
 
 	boolean hasOrigin(OriginLayer layer);
 	boolean hasAllOrigins();

--- a/src/main/java/io/github/apace100/origins/component/PlayerOriginComponent.java
+++ b/src/main/java/io/github/apace100/origins/component/PlayerOriginComponent.java
@@ -8,9 +8,6 @@ import io.github.apace100.origins.origin.OriginRegistry;
 import io.github.apace100.origins.power.Power;
 import io.github.apace100.origins.power.PowerType;
 import io.github.apace100.origins.power.PowerTypeRegistry;
-import io.github.apace100.origins.registry.ModComponents;
-import nerdhub.cardinal.components.api.ComponentType;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -144,7 +141,7 @@ public class PlayerOriginComponent implements OriginComponent {
     }
 
     @Override
-    public void fromTag(CompoundTag compoundTag) {
+    public void readFromNbt(CompoundTag compoundTag) {
         this.fromTag(compoundTag, true);
     }
 
@@ -225,7 +222,7 @@ public class PlayerOriginComponent implements OriginComponent {
     }
 
     @Override
-    public CompoundTag toTag(CompoundTag compoundTag) {
+    public void writeToNbt(CompoundTag compoundTag) {
         ListTag originLayerList = new ListTag();
         for(Map.Entry<OriginLayer, Origin> entry : origins.entrySet()) {
             CompoundTag layerTag = new CompoundTag();
@@ -243,11 +240,10 @@ public class PlayerOriginComponent implements OriginComponent {
             powerList.add(powerTag);
         }
         compoundTag.put("Powers", powerList);
-        return compoundTag;
     }
 
     @Override
-    public void readFromPacket(PacketByteBuf buf) {
+    public void applySyncPacket(PacketByteBuf buf) {
         CompoundTag compoundTag = buf.readCompoundTag();
         if(compoundTag != null) {
             this.fromTag(compoundTag, false);
@@ -255,13 +251,8 @@ public class PlayerOriginComponent implements OriginComponent {
     }
 
     @Override
-    public Entity getEntity() {
-        return this.player;
-    }
-
-    @Override
-    public ComponentType<?> getComponentType() {
-        return ModComponents.ORIGIN;
+    public void sync() {
+        OriginComponent.sync(this.player);
     }
 
     @Override

--- a/src/main/java/io/github/apace100/origins/component/PlayerOriginComponent.java
+++ b/src/main/java/io/github/apace100/origins/component/PlayerOriginComponent.java
@@ -5,9 +5,7 @@ import io.github.apace100.origins.origin.Origin;
 import io.github.apace100.origins.origin.OriginLayer;
 import io.github.apace100.origins.origin.OriginLayers;
 import io.github.apace100.origins.origin.OriginRegistry;
-import io.github.apace100.origins.power.Power;
-import io.github.apace100.origins.power.PowerType;
-import io.github.apace100.origins.power.PowerTypeRegistry;
+import io.github.apace100.origins.power.*;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -137,6 +135,23 @@ public class PlayerOriginComponent implements OriginComponent {
         });
         if(this.hasAllOrigins()) {
             this.hadOriginBefore = true;
+        }
+    }
+
+    @Override
+    public void serverTick() {
+        this.getPowers(Power.class, true).stream().filter(p -> p.shouldTick() && (p.shouldTickWhenInactive() || p.isActive())).forEach(Power::tick);
+            /*this.getPowers(WaterVulnerabilityPower.class).forEach(waterCounter -> {
+                if(this.getFluidHeight(FluidTags.WATER) > 0 || this.isRainingAtPlayerPosition() || this.isSubmergedInWater()) {
+                //if(this.isWet()) {
+                    waterCounter.inWater();
+                } else {
+                    waterCounter.outOfWater();
+                }
+            });*/
+        if(this.player.age % 10 == 0) {
+            this.getPowers(SimpleStatusEffectPower.class).forEach(SimpleStatusEffectPower::applyEffects);
+            this.getPowers(StackingStatusEffectPower.class, true).forEach(StackingStatusEffectPower::tick);
         }
     }
 

--- a/src/main/java/io/github/apace100/origins/mixin/LoginMixin.java
+++ b/src/main/java/io/github/apace100/origins/mixin/LoginMixin.java
@@ -1,5 +1,6 @@
 package io.github.apace100.origins.mixin;
 
+import dev.onyxstudios.cca.api.v3.component.ComponentProvider;
 import io.github.apace100.origins.component.OriginComponent;
 import io.github.apace100.origins.networking.ModPackets;
 import io.github.apace100.origins.origin.Origin;
@@ -71,7 +72,7 @@ public abstract class LoginMixin {
 		ServerSidePacketRegistry.INSTANCE.sendToPlayer(player, ModPackets.LAYER_LIST, originLayerData);
 
 		List<ServerPlayerEntity> playerList = getPlayerList();
-		playerList.forEach(spe -> ModComponents.ORIGIN.get(spe).syncWith(player));
+		playerList.forEach(spe -> ModComponents.ORIGIN.syncWith(spe, ComponentProvider.fromEntity(player)));
 		OriginComponent.sync(player);
 		if(!component.hasAllOrigins()) {
 			PacketByteBuf data = new PacketByteBuf(Unpooled.buffer());

--- a/src/main/java/io/github/apace100/origins/mixin/PlayerEntityMixin.java
+++ b/src/main/java/io/github/apace100/origins/mixin/PlayerEntityMixin.java
@@ -107,28 +107,9 @@ public abstract class PlayerEntityMixin extends LivingEntity implements Nameable
         }
     }
 
-    // HUNGER_OVER_TIME & BURN_IN_DAYLIGHT
-    // WATER_BREATHING & WATER_VULNERABILITY
-    // PARTICLES & EXHAUSTING_WATER_BREATHING
+    // WATER_BREATHING
     @Inject(at = @At("TAIL"), method = "tick")
     private void tick(CallbackInfo info) {
-        if(!world.isClient) {
-            OriginComponent component = ModComponents.ORIGIN.get(this);
-            component.getPowers(Power.class, true).stream().filter(p -> p.shouldTick() && (p.shouldTickWhenInactive() || p.isActive())).forEach(Power::tick);
-            /*component.getPowers(WaterVulnerabilityPower.class).forEach(waterCounter -> {
-                if(this.getFluidHeight(FluidTags.WATER) > 0 || this.isRainingAtPlayerPosition() || this.isSubmergedInWater()) {
-                //if(this.isWet()) {
-                    waterCounter.inWater();
-                } else {
-                    waterCounter.outOfWater();
-                }
-            });*/
-            if(this.age % 10 == 0) {
-                component.getPowers(SimpleStatusEffectPower.class).forEach(SimpleStatusEffectPower::applyEffects);
-                component.getPowers(StackingStatusEffectPower.class, true).forEach(StackingStatusEffectPower::tick);
-            }
-        }
-
         if(PowerTypes.WATER_BREATHING.isActive(this)) {
             if(!this.isSubmergedIn(FluidTags.WATER) && !this.hasStatusEffect(StatusEffects.WATER_BREATHING) && !this.hasStatusEffect(StatusEffects.CONDUIT_POWER)) {
                 if(!this.isRainingAtPlayerPosition()) {

--- a/src/main/java/io/github/apace100/origins/registry/ModComponents.java
+++ b/src/main/java/io/github/apace100/origins/registry/ModComponents.java
@@ -1,26 +1,25 @@
 package io.github.apace100.origins.registry;
 
+import dev.onyxstudios.cca.api.v3.component.ComponentKey;
+import dev.onyxstudios.cca.api.v3.component.ComponentRegistry;
+import dev.onyxstudios.cca.api.v3.entity.EntityComponentFactoryRegistry;
+import dev.onyxstudios.cca.api.v3.entity.EntityComponentInitializer;
 import io.github.apace100.origins.Origins;
 import io.github.apace100.origins.component.OriginComponent;
 import io.github.apace100.origins.component.PlayerOriginComponent;
-import nerdhub.cardinal.components.api.ComponentRegistry;
-import nerdhub.cardinal.components.api.ComponentType;
-import nerdhub.cardinal.components.api.event.EntityComponentCallback;
-import nerdhub.cardinal.components.api.util.EntityComponents;
 import nerdhub.cardinal.components.api.util.RespawnCopyStrategy;
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.Identifier;
 
-public class ModComponents {
+public class ModComponents implements EntityComponentInitializer {
 
-    public static final ComponentType<OriginComponent> ORIGIN;
+    public static final ComponentKey<OriginComponent> ORIGIN;
 
     static {
-        ORIGIN = ComponentRegistry.INSTANCE.registerIfAbsent(new Identifier(Origins.MODID, "origin"), OriginComponent.class);
+        ORIGIN = ComponentRegistry.getOrCreate(new Identifier(Origins.MODID, "origin"), OriginComponent.class);
     }
 
-    public static void register() {
-        EntityComponentCallback.event(PlayerEntity.class).register((player, components) -> components.put(ORIGIN, new PlayerOriginComponent(player)));
-        EntityComponents.setRespawnCopyStrategy(ORIGIN, RespawnCopyStrategy.ALWAYS_COPY);
+    @Override
+    public void registerEntityComponentFactories(EntityComponentFactoryRegistry registry) {
+        registry.registerForPlayers(ORIGIN, PlayerOriginComponent::new, RespawnCopyStrategy.ALWAYS_COPY);
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,11 +29,19 @@
     ],
     "modmenu": [
       "io.github.apace100.origins.integration.ModMenuIntegration"
+    ],
+    "cardinal-components-entity": [
+      "io.github.apace100.origins.registry.ModComponents"
     ]
   },
   "mixins": [
     "origins.mixins.json"
   ],
+  "custom": {
+    "cardinal-components": [
+      "origins:origin"
+    ]
+  },
 
   "depends": {
     "fabricloader": ">=0.7.4",


### PR DESCRIPTION
Fairly simple update, should simplify an eventual 1.17 port (V2 API is planned to disappear during that update cycle). I took the opportunity to move some ticking logic to the component itself, using the new TickingComponent interface.

Possible improvement: you could probably use the new sync API to selectively send updated data instead of everything at once, may optimize network usage a bit.