### PR TITLE
Correctly register argument types with a namespace

### DIFF
--- a/src/main/java/io/github/apace100/origins/Origins.java
+++ b/src/main/java/io/github/apace100/origins/Origins.java
@@ -60,8 +60,8 @@ public class Origins implements ModInitializer {
 		});
 		CriteriaRegistryInvoker.callRegister(ChoseOriginCriterion.INSTANCE);
 		CriteriaRegistryInvoker.callRegister(GainedPowerCriterion.INSTANCE);
-		ArgumentTypes.register("origin", OriginArgument.class, new ConstantArgumentSerializer<>(OriginArgument::origin));
-		ArgumentTypes.register("layer", LayerArgument.class, new ConstantArgumentSerializer<>(LayerArgument::layer));
+		ArgumentTypes.register("origins:origin", OriginArgument.class, new ConstantArgumentSerializer<>(OriginArgument::origin));
+		ArgumentTypes.register("origins:layer", LayerArgument.class, new ConstantArgumentSerializer<>(LayerArgument::layer));
 		ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(new PowerTypes());
 		ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(new OriginManager());
 		ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(new OriginLayers());


### PR DESCRIPTION
As per [Dinnerbone when namespaces were first introduced](https://www.minecraft.net/en-us/article/minecraft-snapshot-17w43a):

> Please always use your own namespace for anything new that you add, and only use other namespaces if you're explicitly overriding something else. Try not to add new things in `minecraft`, basically.

Violating this practice causes the mod to not work with Minecraft proxies such as [Velocity](https://velocitypowered.com/) which can forward custom argument types from mods with the assistance of [CrossStitch](https://github.com/VelocityPowered/CrossStitch).

(Note this will require the client and server to be updated to work.)