### PR TITLE
Change how Depth Strider works with swim_speed powers

### DIFF
--- a/src/main/java/io/github/apace100/origins/mixin/LivingEntityMixin.java
+++ b/src/main/java/io/github/apace100/origins/mixin/LivingEntityMixin.java
@@ -4,6 +4,7 @@ import io.github.apace100.origins.Origins;
 import io.github.apace100.origins.component.OriginComponent;
 import io.github.apace100.origins.power.*;
 import io.github.apace100.origins.registry.ModComponents;
+import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityGroup;
 import net.minecraft.entity.EntityType;
@@ -20,6 +21,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import java.util.NoSuchElementException;
 
 import java.util.List;
 import java.util.Optional;
@@ -166,6 +168,17 @@ public abstract class LivingEntityMixin extends Entity {
             }
         }
         return entity.method_26317(d, bl, vec3d);
+    }
+    
+    @Redirect(method = "travel", at = @At(value = "INVOKE", target = "Lnet/minecraft/enchantment/EnchantmentHelper;getDepthStrider(Lnet/minecraft/entity/LivingEntity;)I"))
+    public int getDepthStriderProxy(LivingEntity entity) {
+    	if (entity instanceof PlayerEntity) {
+            List<ModifySwimSpeedPower> swimspeedpowers = ModComponents.ORIGIN.get(entity).getPowers(ModifySwimSpeedPower.class);
+            if (swimspeedpowers.size()>0) {
+                return 0;
+            }
+    	}
+        return EnchantmentHelper.getDepthStrider(entity);
     }
 
     // SLOW_FALLING

--- a/src/main/java/io/github/apace100/origins/mixin/LivingEntityMixin.java
+++ b/src/main/java/io/github/apace100/origins/mixin/LivingEntityMixin.java
@@ -21,7 +21,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import java.util.NoSuchElementException;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/io/github/apace100/origins/power/factory/condition/EntityConditions.java
+++ b/src/main/java/io/github/apace100/origins/power/factory/condition/EntityConditions.java
@@ -43,6 +43,7 @@ import net.minecraft.util.math.Box;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.biome.Biome;
+import net.minecraft.enchantment.EnchantmentHelper;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -220,6 +221,10 @@ public class EntityConditions {
             .add("comparison", SerializableDataType.COMPARISON)
             .add("compare_to", SerializableDataType.INT),
             (data, entity) -> ((Comparison)data.get("comparison")).compare(entity.getAir(), data.getInt("compare_to"))));
+        register(new ConditionFactory<>(Origins.identifier("depth_strider"), new SerializableData()
+                .add("comparison", SerializableDataType.COMPARISON)
+                .add("compare_to", SerializableDataType.INT),
+                (data, entity) -> ((Comparison)data.get("comparison")).compare(EnchantmentHelper.getDepthStrider(entity), data.getInt("compare_to"))));
         register(new ConditionFactory<>(Origins.identifier("in_block"), new SerializableData()
             .add("block_condition", SerializableDataType.BLOCK_CONDITION),
             (data, entity) ->((ConditionFactory<CachedBlockPosition>.Instance)data.get("block_condition")).test(

--- a/src/main/resources/data/origins/powers/swim_speed.json
+++ b/src/main/resources/data/origins/powers/swim_speed.json
@@ -1,8 +1,50 @@
 {
-  "type": "origins:modify_swim_speed",
-  "modifier": {
-    "name": "Additional swim speed",
-    "value": 0.04,
-    "operation": "addition"
+  "type": "origins:multiple",
+  "main": {
+      "type": "origins:modify_swim_speed",
+      "modifier": {
+        "name": "Additional swim speed",
+        "value": 0.04,
+        "operation": "addition"
+      }
+  },
+  "depth_strider_1": {
+      "type": "origins:modify_swim_speed",
+      "modifier": {
+        "name": "Additional swim speed for Depth Strider 1",
+        "value": 0.04,
+        "operation": "addition"
+      },
+      "condition": {
+        "type": "origins:depth_strider",
+        "comparison": ">=",
+        "compare_to": 1
+      }
+  },
+  "depth_strider_2": {
+      "type": "origins:modify_swim_speed",
+      "modifier": {
+        "name": "Additional swim speed for Depth Strider 1",
+        "value": 0.04,
+        "operation": "addition"
+      },
+      "condition": {
+        "type": "origins:depth_strider",
+        "comparison": ">=",
+        "compare_to": 2
+      }
+  },
+  "depth_strider_3": {
+      "type": "origins:modify_swim_speed",
+      "modifier": {
+        "name": "Additional swim speed for Depth Strider 1",
+        "value": 0.04,
+        "operation": "addition"
+      },
+      "condition": {
+        "type": "origins:depth_strider",
+        "comparison": ">=",
+        "compare_to": 3
+      }
   }
 }


### PR DESCRIPTION
Effectively, if any `origins:modify_swim_speed` powers are detected, vanilla handling of Depth Strider is pawned off to them. To accommodate that, a new entity condition, `origins:depth_strider`, is added, which allows you to check the player's Depth Strider level.

Also, the `origins:swim_speed` power (Fins) now handles Depth Strider, adding 0.04 to base swim speed for every Depth Strider level. Probably overpowered, but it's there to be nerfed.