### PR TITLE
Update build.gradle to improve compatibility with other projects that use Cardinal Components API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,10 +43,10 @@ dependencies {
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
 	modImplementation "io.github.OnyxStudios.Cardinal-Components-API:cardinal-components-base:${project.cca_version}"
-	include "io.github.OnyxStudios.Cardinal-Components-API:cardinal-components-base:${project.cca_version}"
+	include "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-base:${project.cca_version}"
 
 	modImplementation "io.github.OnyxStudios.Cardinal-Components-API:cardinal-components-entity:${project.cca_version}"
-	include "io.github.OnyxStudios.Cardinal-Components-API:cardinal-components-entity:${project.cca_version}"
+	include "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-entity:${project.cca_version}"
 
 	modImplementation "com.jamieswhiteshirt:reach-entity-attributes:${project.reach_version}"
 	include "com.jamieswhiteshirt:reach-entity-attributes:${project.reach_version}"


### PR DESCRIPTION
This should fix a bug I found when setting up a dev environment for an addon that uses Artifacts API. It was putting two copies of CC in the dev environment, one under the maven group "io.github.OnyxStudios.Cardinal-Components-API" and one under "io.github.onyxstudios.Cardinal-Components-API", and since the CC README says to use the lowercase version, the latter would likely offer better compatibility. Note that without the temporary fix I used in my buildscript, the project could build as normal, but the launch profile would not run correctly.