### PR TITLE
Update FallFlyingLib implementation to use Jitpack host

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,7 @@ repositories {
 		url = 'https://ladysnake.jfrog.io/artifactory/mods'
 	}
 	maven {
-		name = "AdrianTodt's Maven"
-		url = "https://dl.bintray.com/adriantodt/maven"
+		url 'https://jitpack.io'
 	}
 	maven {
 		url "https://maven.jamieswhiteshirt.com/libs-release/"
@@ -48,8 +47,8 @@ dependencies {
 	modImplementation "com.jamieswhiteshirt:reach-entity-attributes:${project.reach_version}"
 	include "com.jamieswhiteshirt:reach-entity-attributes:${project.reach_version}"
 
-	modImplementation "net.adriantodt.fabricmc:fallflyinglib:${project.ffl_version}"
-	include "net.adriantodt.fabricmc:fallflyinglib:${project.ffl_version}"
+	modImplementation "com.github.adriantodt:FallFlyingLib:${project.ffl_version}"
+	include "com.github.adriantodt:FallFlyingLib:${project.ffl_version}"
 
 	modApi("me.shedaniel.cloth:cloth-config-fabric:${project.clothconfig_version}") {
 		exclude(group: "net.fabricmc.fabric-api")

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
 		url = 'https://ladysnake.jfrog.io/artifactory/mods'
 	}
 	maven {
-		url 'https://jitpack.io'
+		url "https://jitpack.io"
 	}
 	maven {
 		url "https://maven.jamieswhiteshirt.com/libs-release/"


### PR DESCRIPTION
Since bintray is permanently down, refreshing dependencies and generating sources aren't working. This harms addons that want to update specifically.

My fix for this is that I made FallFlyingLib collect from it's Jitpack link as opposed to its bintray one.