### PR TITLE
base_stone_overworld and base_stone_nether tags instead of blocks IDs in natural_stone.json

### DIFF
--- a/src/main/resources/data/origins/tags/blocks/natural_stone.json
+++ b/src/main/resources/data/origins/tags/blocks/natural_stone.json
@@ -1,12 +1,7 @@
 {
   "replace": false,
   "values": [
-    "minecraft:stone",
-    "minecraft:diorite",
-    "minecraft:andesite",
-    "minecraft:granite",
-    "minecraft:netherrack",
-    "minecraft:blackstone",
-    "minecraft:basalt"
+    "#minecraft:base_stone_overworld",
+    "#minecraft:base_stone_nether"
   ]
 }


### PR DESCRIPTION
I replaced, in natural_stone.json, the block IDs with base_stone_overworld and base_stone_nether tags including those same block IDs to avoid some incompatibilities with mods that adds natural stones like here: https://github.com/Brandcraf06/Blockus/issues/107