### PR TITLE
Make SerializableData fields iterate in insertion order, not hash order

### DIFF
--- a/src/main/java/io/github/apace100/origins/util/SerializableData.java
+++ b/src/main/java/io/github/apace100/origins/util/SerializableData.java
@@ -8,11 +8,12 @@ import net.minecraft.network.PacketByteBuf;
 import net.minecraft.util.Identifier;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.function.Function;
 
 public class SerializableData {
 
-    private HashMap<String, Entry<?>> dataFields = new HashMap<>();
+    private LinkedHashMap<String, Entry<?>> dataFields = new LinkedHashMap<>();
 
     public SerializableData add(String name, SerializableDataType<?> type) {
         dataFields.put(name, new Entry<>(type));


### PR DESCRIPTION
This should fix the issue if I'm not mistaken.