### PR TITLE
Use multiplier to determine health level

### DIFF
--- a/src/main/resources/data/origins/powers/fragile.json
+++ b/src/main/resources/data/origins/powers/fragile.json
@@ -3,7 +3,7 @@
   "modifier": {
     "name": "Fragile health reduction",
     "attribute": "minecraft:generic.max_health",
-    "value": -6.0,
-    "operation": "addition"
+    "value": -0.3,
+    "operation": "multiply_base"
   }
 }

--- a/src/main/resources/data/origins/powers/nine_lives.json
+++ b/src/main/resources/data/origins/powers/nine_lives.json
@@ -3,7 +3,7 @@
   "modifier": {
     "name": "Nine lives health reduction",
     "attribute": "minecraft:generic.max_health",
-    "value": -2.0,
+    "value": -0.1,
     "operation": "addition"
   }
 }

--- a/src/main/resources/data/origins/powers/nine_lives.json
+++ b/src/main/resources/data/origins/powers/nine_lives.json
@@ -4,6 +4,6 @@
     "name": "Nine lives health reduction",
     "attribute": "minecraft:generic.max_health",
     "value": -0.1,
-    "operation": "addition"
+    "operation": "multiply_base"
   }
 }


### PR DESCRIPTION
Instead of removing e.g. 10 health levels to start with 5 hearts, 50% of the health level should be used. This way, the mod becomes more compatible to other mods like spiceoffabric or healthlevels, without changing the original idea of the reduced health level.

Currently, when starting a world with spiceoffabric in carrot mode, the inchling will only have one heart, because spiceoffabric reduces the health level by 8 (pr open to make it use 60% hl's instead of always reducing the hl by 8). Then, this mod reduces it by another 10 to only 2 left.

This could also lead to a case where the player had negetive health levels.
This can be prevented by using a multiplier: spiceoffabric sets it to 60% of 20 = 12, extra-origins sets it to 50% of this, leaving the player with 6 hl's or 3 hearts.

Another example:
Let's say I have 3 mods: origins, spiceoffabric and healthlevels.

Currently,
Healthlevels sets the starting hl to 10. Spiceoffabric then reduces it by 8. origins reduces it by 10 again.
The player is left with -8 health levels.

With these changes, healthlevels would still reduce it by 10 to 10 (wil create a pr there to fix this as well), but spiceoffabric sets the hl to 60% of that (6), and origins to 50% of this (3), so the player is left with 1.5 hearts, instead of negative hearts.

The proposed changes are tested and are confirmed to work as expected. though, additional testing is off course welcome as well as comments or ideas to improve mod compatibility even more.

This pull request might need a change in the description of the power, as it's technically not "5 hearts less" anymore but "50% of the hearts", though it doesn't make a change without additional mods changing the health level (same for piglin).

It should be noted that this change should be proposed to all origin addons making use of this feature to stay consistent! Though this change isn't big and easy to implement.