### PR TITLE
Add a way to override the titles in the view/choose origin layer GUIs

### DIFF
--- a/src/main/java/io/github/apace100/origins/origin/OriginLayer.java
+++ b/src/main/java/io/github/apace100/origins/origin/OriginLayer.java
@@ -28,6 +28,8 @@ public class OriginLayer implements Comparable<OriginLayer> {
     private boolean enabled = false;
 
     private String nameTranslationKey;
+    private String nameViewOriginTranslationKey;
+    private String nameChooseOriginTranslationKey;
     private String missingOriginNameTranslationKey;
     private String missingOriginDescriptionTranslationKey;
 
@@ -38,6 +40,7 @@ public class OriginLayer implements Comparable<OriginLayer> {
     private Identifier defaultOrigin = null;
     private boolean autoChooseIfNoChoice = false;
 
+    private boolean overrideName = false;
     private boolean hidden = false;
 
     public String getOrCreateTranslationKey() {
@@ -56,6 +59,24 @@ public class OriginLayer implements Comparable<OriginLayer> {
             this.missingOriginNameTranslationKey = "layer." + identifier.getNamespace() + "." + identifier.getPath() + ".missing_origin.name";
         }
         return missingOriginNameTranslationKey;
+    }
+
+    public String getNameViewOriginTranslationKey() {
+        if(nameViewOriginTranslationKey == null || nameViewOriginTranslationKey.isEmpty()) {
+            this.nameViewOriginTranslationKey = "layer." + identifier.getNamespace() + "." + identifier.getPath() + ".view_origin.name";
+        }
+        return nameViewOriginTranslationKey;
+    }
+
+    public String getNameChooseOriginTranslationKey() {
+        if(nameChooseOriginTranslationKey == null || nameChooseOriginTranslationKey.isEmpty()) {
+            this.nameChooseOriginTranslationKey = "layer." + identifier.getNamespace() + "." + identifier.getPath() + ".choose_origin.name";
+        }
+        return nameChooseOriginTranslationKey;
+    }
+
+    public boolean overrideName() {
+        return overrideName;
     }
 
     public String getMissingOriginDescriptionTranslationKey() {
@@ -135,6 +156,12 @@ public class OriginLayer implements Comparable<OriginLayer> {
         if(json.has("name")) {
             this.nameTranslationKey = JsonHelper.getString(json, "name", "");
         }
+        if(json.has("name_view_origin")) {
+            this.nameViewOriginTranslationKey = JsonHelper.getString(json, "name_view_origin", "");
+        }
+        if(json.has("name_choose_origin")) {
+            this.nameChooseOriginTranslationKey = JsonHelper.getString(json, "name_choose_origin", "");
+        }
         if(json.has("missing_name")) {
             this.missingOriginNameTranslationKey = JsonHelper.getString(json, "missing_name", "");
         }
@@ -194,6 +221,8 @@ public class OriginLayer implements Comparable<OriginLayer> {
         buffer.writeInt(conditionedOrigins.size());
         conditionedOrigins.forEach(co -> co.write(buffer));
         buffer.writeString(getOrCreateTranslationKey());
+        buffer.writeString(getNameViewOriginTranslationKey());
+        buffer.writeString(getNameChooseOriginTranslationKey());
         buffer.writeString(getMissingOriginNameTranslationKey());
         buffer.writeString(getMissingOriginDescriptionTranslationKey());
         buffer.writeBoolean(isRandomAllowed());
@@ -208,6 +237,7 @@ public class OriginLayer implements Comparable<OriginLayer> {
         }
         buffer.writeBoolean(autoChooseIfNoChoice);
         buffer.writeBoolean(hidden);
+        buffer.writeBoolean(overrideName);
     }
 
     @Environment(EnvType.CLIENT)
@@ -222,6 +252,8 @@ public class OriginLayer implements Comparable<OriginLayer> {
             layer.conditionedOrigins.add(ConditionedOrigin.read(buffer));
         }
         layer.nameTranslationKey = buffer.readString();
+        layer.nameViewOriginTranslationKey = buffer.readString();
+        layer.nameChooseOriginTranslationKey = buffer.readString();
         layer.missingOriginNameTranslationKey = buffer.readString();
         layer.missingOriginDescriptionTranslationKey = buffer.readString();
         layer.isRandomAllowed = buffer.readBoolean();
@@ -238,6 +270,7 @@ public class OriginLayer implements Comparable<OriginLayer> {
         }
         layer.autoChooseIfNoChoice = buffer.readBoolean();
         layer.hidden = buffer.readBoolean();
+        layer.overrideName = buffer.readBoolean();
         return layer;
     }
 
@@ -256,6 +289,8 @@ public class OriginLayer implements Comparable<OriginLayer> {
         layer.enabled = enabled;
         layer.identifier = id;
         layer.nameTranslationKey = JsonHelper.getString(json, "name", "");
+        layer.nameViewOriginTranslationKey = JsonHelper.getString(json, "name_view_origin", "");
+        layer.nameChooseOriginTranslationKey = JsonHelper.getString(json, "name_choose_origin", "");
         layer.missingOriginNameTranslationKey = JsonHelper.getString(json, "missing_name", "");
         layer.missingOriginDescriptionTranslationKey = JsonHelper.getString(json, "missing_description", "");
 
@@ -271,6 +306,9 @@ public class OriginLayer implements Comparable<OriginLayer> {
         }
         layer.autoChooseIfNoChoice = JsonHelper.getBoolean(json, "auto_choose", false);
         layer.hidden = JsonHelper.getBoolean(json, "hidden", false);
+        if(json.has("name_view_origin") || json.has("name_choose_origin")) {
+            layer.overrideName = true;
+        }
         return layer;
     }
 

--- a/src/main/java/io/github/apace100/origins/origin/OriginLayer.java
+++ b/src/main/java/io/github/apace100/origins/origin/OriginLayer.java
@@ -28,8 +28,8 @@ public class OriginLayer implements Comparable<OriginLayer> {
     private boolean enabled = false;
 
     private String nameTranslationKey;
-    private String nameViewOriginTranslationKey;
-    private String nameChooseOriginTranslationKey;
+    private String titleViewOriginTranslationKey;
+    private String titleChooseOriginTranslationKey;
     private String missingOriginNameTranslationKey;
     private String missingOriginDescriptionTranslationKey;
 
@@ -41,8 +41,8 @@ public class OriginLayer implements Comparable<OriginLayer> {
     private boolean autoChooseIfNoChoice = false;
 
     private boolean hidden = false;
-    private boolean overrideViewOriginName = false;
-    private boolean overrideChooseOriginName = false;
+    private boolean overrideViewOriginTitle = false;
+    private boolean overrideChooseOriginTitle = false;
 
     public String getOrCreateTranslationKey() {
         if(nameTranslationKey == null || nameTranslationKey.isEmpty()) {
@@ -62,26 +62,26 @@ public class OriginLayer implements Comparable<OriginLayer> {
         return missingOriginNameTranslationKey;
     }
 
-    public String getNameViewOriginTranslationKey() {
-        if(nameViewOriginTranslationKey == null || nameViewOriginTranslationKey.isEmpty()) {
-            this.nameViewOriginTranslationKey = "layer." + identifier.getNamespace() + "." + identifier.getPath() + ".view_origin.name";
+    public String getTitleViewOriginTranslationKey() {
+        if(titleViewOriginTranslationKey == null || titleViewOriginTranslationKey.isEmpty()) {
+            this.titleViewOriginTranslationKey = "layer." + identifier.getNamespace() + "." + identifier.getPath() + ".view_origin.name";
         }
-        return nameViewOriginTranslationKey;
+        return titleViewOriginTranslationKey;
     }
 
-    public boolean overrideViewOriginName() {
-        return overrideViewOriginName;
+    public boolean shouldOverrideViewOriginTitle() {
+        return overrideViewOriginTitle;
     }
 
-    public String getNameChooseOriginTranslationKey() {
-        if(nameChooseOriginTranslationKey == null || nameChooseOriginTranslationKey.isEmpty()) {
-            this.nameChooseOriginTranslationKey = "layer." + identifier.getNamespace() + "." + identifier.getPath() + ".choose_origin.name";
+    public String getTitleChooseOriginTranslationKey() {
+        if(titleChooseOriginTranslationKey == null || titleChooseOriginTranslationKey.isEmpty()) {
+            this.titleChooseOriginTranslationKey = "layer." + identifier.getNamespace() + "." + identifier.getPath() + ".choose_origin.name";
         }
-        return nameChooseOriginTranslationKey;
+        return titleChooseOriginTranslationKey;
     }
 
-    public boolean overrideChooseOriginName() {
-        return overrideChooseOriginName;
+    public boolean shouldOverrideChooseOriginTitle() {
+        return overrideChooseOriginTitle;
     }
 
     public String getMissingOriginDescriptionTranslationKey() {
@@ -161,13 +161,13 @@ public class OriginLayer implements Comparable<OriginLayer> {
         if(json.has("name")) {
             this.nameTranslationKey = JsonHelper.getString(json, "name", "");
         }
-        if(json.has("name_override")) {
-            JsonObject nameOverrideObj = json.getAsJsonObject("name_override");
-            if(nameOverrideObj.has("view_origin")) {
-                this.nameViewOriginTranslationKey = JsonHelper.getString(nameOverrideObj, "view_origin", "");
+        if(json.has("gui_title")) {
+            JsonObject guiTitleObj = json.getAsJsonObject("gui_title");
+            if(guiTitleObj.has("view_origin")) {
+                this.titleViewOriginTranslationKey = JsonHelper.getString(guiTitleObj, "view_origin", "");
             }
-            if(nameOverrideObj.has("choose_origin")) {
-                this.nameChooseOriginTranslationKey = JsonHelper.getString(nameOverrideObj, "choose_origin", "");
+            if(guiTitleObj.has("choose_origin")) {
+                this.titleChooseOriginTranslationKey = JsonHelper.getString(guiTitleObj, "choose_origin", "");
             }
         }
         if(json.has("missing_name")) {
@@ -229,8 +229,8 @@ public class OriginLayer implements Comparable<OriginLayer> {
         buffer.writeInt(conditionedOrigins.size());
         conditionedOrigins.forEach(co -> co.write(buffer));
         buffer.writeString(getOrCreateTranslationKey());
-        buffer.writeString(getNameViewOriginTranslationKey());
-        buffer.writeString(getNameChooseOriginTranslationKey());
+        buffer.writeString(getTitleViewOriginTranslationKey());
+        buffer.writeString(getTitleChooseOriginTranslationKey());
         buffer.writeString(getMissingOriginNameTranslationKey());
         buffer.writeString(getMissingOriginDescriptionTranslationKey());
         buffer.writeBoolean(isRandomAllowed());
@@ -245,8 +245,8 @@ public class OriginLayer implements Comparable<OriginLayer> {
         }
         buffer.writeBoolean(autoChooseIfNoChoice);
         buffer.writeBoolean(hidden);
-        buffer.writeBoolean(overrideViewOriginName);
-        buffer.writeBoolean(overrideChooseOriginName);
+        buffer.writeBoolean(overrideViewOriginTitle);
+        buffer.writeBoolean(overrideChooseOriginTitle);
     }
 
     @Environment(EnvType.CLIENT)
@@ -261,8 +261,8 @@ public class OriginLayer implements Comparable<OriginLayer> {
             layer.conditionedOrigins.add(ConditionedOrigin.read(buffer));
         }
         layer.nameTranslationKey = buffer.readString();
-        layer.nameViewOriginTranslationKey = buffer.readString();
-        layer.nameChooseOriginTranslationKey = buffer.readString();
+        layer.titleViewOriginTranslationKey = buffer.readString();
+        layer.titleChooseOriginTranslationKey = buffer.readString();
         layer.missingOriginNameTranslationKey = buffer.readString();
         layer.missingOriginDescriptionTranslationKey = buffer.readString();
         layer.isRandomAllowed = buffer.readBoolean();
@@ -279,8 +279,8 @@ public class OriginLayer implements Comparable<OriginLayer> {
         }
         layer.autoChooseIfNoChoice = buffer.readBoolean();
         layer.hidden = buffer.readBoolean();
-        layer.overrideViewOriginName = buffer.readBoolean();
-        layer.overrideChooseOriginName = buffer.readBoolean();
+        layer.overrideViewOriginTitle = buffer.readBoolean();
+        layer.overrideChooseOriginTitle = buffer.readBoolean();
         return layer;
     }
 
@@ -299,15 +299,15 @@ public class OriginLayer implements Comparable<OriginLayer> {
         layer.enabled = enabled;
         layer.identifier = id;
         layer.nameTranslationKey = JsonHelper.getString(json, "name", "");
-        if(json.has("name_override") && json.get("name_override").isJsonObject()) {
-            JsonObject nameOverrideObj = json.getAsJsonObject("name_override");
-            if(nameOverrideObj.has("view_origin")) {
-                layer.nameViewOriginTranslationKey = JsonHelper.getString(nameOverrideObj, "view_origin", "");
-                layer.overrideViewOriginName = true;
+        if(json.has("gui_title") && json.get("gui_title").isJsonObject()) {
+            JsonObject guiTitleObj = json.getAsJsonObject("gui_title");
+            if(guiTitleObj.has("view_origin")) {
+                layer.titleViewOriginTranslationKey = JsonHelper.getString(guiTitleObj, "view_origin", "");
+                layer.overrideViewOriginTitle = true;
             }
-            if(nameOverrideObj.has("choose_origin")) {
-                layer.nameChooseOriginTranslationKey = JsonHelper.getString(nameOverrideObj, "choose_origin", "");
-                layer.overrideChooseOriginName = true;
+            if(guiTitleObj.has("choose_origin")) {
+                layer.titleChooseOriginTranslationKey = JsonHelper.getString(guiTitleObj, "choose_origin", "");
+                layer.overrideChooseOriginTitle = true;
             }
         }
         layer.missingOriginNameTranslationKey = JsonHelper.getString(json, "missing_name", "");

--- a/src/main/java/io/github/apace100/origins/screen/ChooseOriginScreen.java
+++ b/src/main/java/io/github/apace100/origins/screen/ChooseOriginScreen.java
@@ -110,8 +110,8 @@ public class ChooseOriginScreen extends OriginDisplayScreen {
 
 	@Override
 	protected Text getTitleText() {
-		if (getCurrentLayer().overrideChooseOriginName()) {
-			return new TranslatableText(getCurrentLayer().getNameChooseOriginTranslationKey());
+		if (getCurrentLayer().shouldOverrideChooseOriginTitle()) {
+			return new TranslatableText(getCurrentLayer().getTitleChooseOriginTranslationKey());
 		}
 		return new TranslatableText(Origins.MODID + ".gui.choose_origin.title", new TranslatableText(getCurrentLayer().getTranslationKey()));
 	}

--- a/src/main/java/io/github/apace100/origins/screen/ChooseOriginScreen.java
+++ b/src/main/java/io/github/apace100/origins/screen/ChooseOriginScreen.java
@@ -110,7 +110,7 @@ public class ChooseOriginScreen extends OriginDisplayScreen {
 
 	@Override
 	protected Text getTitleText() {
-		if (getCurrentLayer().overrideName()) {
+		if (getCurrentLayer().overrideChooseOriginName()) {
 			return new TranslatableText(getCurrentLayer().getNameChooseOriginTranslationKey());
 		}
 		return new TranslatableText(Origins.MODID + ".gui.choose_origin.title", new TranslatableText(getCurrentLayer().getTranslationKey()));

--- a/src/main/java/io/github/apace100/origins/screen/ChooseOriginScreen.java
+++ b/src/main/java/io/github/apace100/origins/screen/ChooseOriginScreen.java
@@ -110,6 +110,9 @@ public class ChooseOriginScreen extends OriginDisplayScreen {
 
 	@Override
 	protected Text getTitleText() {
+		if (getCurrentLayer().overrideName()) {
+			return new TranslatableText(getCurrentLayer().getNameChooseOriginTranslationKey());
+		}
 		return new TranslatableText(Origins.MODID + ".gui.choose_origin.title", new TranslatableText(getCurrentLayer().getTranslationKey()));
 	}
 

--- a/src/main/java/io/github/apace100/origins/screen/ViewOriginScreen.java
+++ b/src/main/java/io/github/apace100/origins/screen/ViewOriginScreen.java
@@ -101,6 +101,9 @@ public class ViewOriginScreen extends OriginDisplayScreen {
 
 	@Override
 	protected Text getTitleText() {
+		if (getCurrentLayer().overrideName()) {
+			return new TranslatableText(getCurrentLayer().getNameViewOriginTranslationKey());
+		}
 		return new TranslatableText(Origins.MODID + ".gui.view_origin.title", new TranslatableText(getCurrentLayer().getTranslationKey()));
 	}
 

--- a/src/main/java/io/github/apace100/origins/screen/ViewOriginScreen.java
+++ b/src/main/java/io/github/apace100/origins/screen/ViewOriginScreen.java
@@ -101,8 +101,8 @@ public class ViewOriginScreen extends OriginDisplayScreen {
 
 	@Override
 	protected Text getTitleText() {
-		if (getCurrentLayer().overrideViewOriginName()) {
-			return new TranslatableText(getCurrentLayer().getNameViewOriginTranslationKey());
+		if (getCurrentLayer().shouldOverrideViewOriginTitle()) {
+			return new TranslatableText(getCurrentLayer().getTitleViewOriginTranslationKey());
 		}
 		return new TranslatableText(Origins.MODID + ".gui.view_origin.title", new TranslatableText(getCurrentLayer().getTranslationKey()));
 	}

--- a/src/main/java/io/github/apace100/origins/screen/ViewOriginScreen.java
+++ b/src/main/java/io/github/apace100/origins/screen/ViewOriginScreen.java
@@ -101,7 +101,7 @@ public class ViewOriginScreen extends OriginDisplayScreen {
 
 	@Override
 	protected Text getTitleText() {
-		if (getCurrentLayer().overrideName()) {
+		if (getCurrentLayer().overrideViewOriginName()) {
 			return new TranslatableText(getCurrentLayer().getNameViewOriginTranslationKey());
 		}
 		return new TranslatableText(Origins.MODID + ".gui.view_origin.title", new TranslatableText(getCurrentLayer().getTranslationKey()));


### PR DESCRIPTION
This PR adds an optional `name_override` object field in the format of origin layers that consists of two optional string fields: `view_origin` and `choose_origin`. These fields overrides the title for viewing/choosing an origin in an origin layer respectively.

This implementation should be backwards-compatible with datapacks/addons that add their own layer(s), since it does not completely replace how origin layer names are defined