### PR TITLE
Add support for Enchantment Descriptions

### DIFF
--- a/src/main/resources/assets/origins/lang/en_us.json
+++ b/src/main/resources/assets/origins/lang/en_us.json
@@ -191,6 +191,7 @@
   "item.origins.orb_of_origin.layer_specific": "Sets your %1$s to \"%2$s\".",
 
   "enchantment.origins.water_protection": "Water Protection",
+  "enchantment.origins.water_protection.desc": "Protects from damage when touching water.",
 
   "container.shulker_inventory_power": "Shulker Inventory",
 


### PR DESCRIPTION
This PR adds support for [Enchantment Descriptions](https://www.curseforge.com/minecraft/mc-mods/enchantment-descriptions) and other mods with similar features.