### PR TITLE
Origins in 22w16b (Preview/Kind Of Successful)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,19 +2,20 @@
 org.gradle.jvmargs=-Xmx4G
 
 # Fabric Properties
-	minecraft_version=1.18.2
-	yarn_mappings=1.18.2+build.2
-	loader_version=0.13.3
+       minecraft_version=22w16b
+       yarn_mappings=22w16b+build.7
+       loader_version=0.14.1
+
 
 # Mod Properties
-	mod_version = 1.4.1
+	mod_version = 1.4.2
 	maven_group = com.github.apace100
-	archives_base_name = Origins-1.18.2
+	archives_base_name = Origins-22w16b
 
 # Dependencies
-	fabric_version=0.48.0+1.18.2
+	fabric_version=0.51.2+1.19
 	cca_version=4.1.4
 	apoli_version=v2.3.3
 	reach_version=2.1.1
-	clothconfig_version=6.2.57
-	modmenu_version=3.1.0
+	clothconfig_version=7.0.61
+	modmenu_version=4.0.0-beta.4

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/io/github/apace100/origins/command/LayerArgumentType.java
+++ b/src/main/java/io/github/apace100/origins/command/LayerArgumentType.java
@@ -11,7 +11,7 @@ import io.github.apace100.origins.origin.OriginLayer;
 import io.github.apace100.origins.origin.OriginLayers;
 import net.minecraft.command.CommandSource;
 import net.minecraft.server.command.ServerCommandSource;
-import net.minecraft.text.TranslatableText;
+import net.minecraft.text.TranslatableTextContent;
 import net.minecraft.util.Identifier;
 
 import java.util.concurrent.CompletableFuture;

--- a/src/main/java/io/github/apace100/origins/command/OriginArgumentType.java
+++ b/src/main/java/io/github/apace100/origins/command/OriginArgumentType.java
@@ -12,7 +12,7 @@ import io.github.apace100.origins.origin.OriginLayer;
 import io.github.apace100.origins.origin.OriginRegistry;
 import net.minecraft.command.CommandSource;
 import net.minecraft.server.command.ServerCommandSource;
-import net.minecraft.text.TranslatableText;
+import net.minecraft.text.TranslatableTextContent;
 import net.minecraft.util.Identifier;
 
 import java.util.LinkedList;

--- a/src/main/java/io/github/apace100/origins/command/OriginCommand.java
+++ b/src/main/java/io/github/apace100/origins/command/OriginCommand.java
@@ -14,7 +14,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.text.TranslatableText;
+import net.minecraft.text.TranslatableTextContent;
 
 import java.util.Collection;
 

--- a/src/main/java/io/github/apace100/origins/content/OrbOfOriginItem.java
+++ b/src/main/java/io/github/apace100/origins/content/OrbOfOriginItem.java
@@ -21,7 +21,7 @@ import net.minecraft.nbt.NbtList;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
-import net.minecraft.text.TranslatableText;
+import net.minecraft.text.TranslatableTextContent;
 import net.minecraft.util.*;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/io/github/apace100/origins/mixin/OriginUpgradeMixin.java
+++ b/src/main/java/io/github/apace100/origins/mixin/OriginUpgradeMixin.java
@@ -10,7 +10,7 @@ import net.minecraft.advancement.Advancement;
 import net.minecraft.advancement.AdvancementProgress;
 import net.minecraft.advancement.PlayerAdvancementTracker;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.text.TranslatableText;
+import net.minecraft.text.TranslatableTextContent;
 import net.minecraft.util.Formatting;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;

--- a/src/main/java/io/github/apace100/origins/networking/ModPacketsC2S.java
+++ b/src/main/java/io/github/apace100/origins/networking/ModPacketsC2S.java
@@ -13,8 +13,8 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerLoginNetworkHandler;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.text.LiteralText;
-import net.minecraft.text.TranslatableText;
+import net.minecraft.text.LiteralTextContent;
+import net.minecraft.text.TranslatableTextContent;
 import net.minecraft.util.Identifier;
 
 import java.util.List;

--- a/src/main/java/io/github/apace100/origins/origin/Impact.java
+++ b/src/main/java/io/github/apace100/origins/origin/Impact.java
@@ -32,8 +32,8 @@ public enum Impact {
 		return textStyle;
 	}
 	
-	public TranslatableTextContent getTextComponent() {
-		return (TranslatableText)new TranslatableText(getTranslationKey()).formatted(getTextStyle());
+	public translatable getTextComponent() {
+		return (TranslatableText)new translatable(getTranslationKey()).formatted(getTextStyle());
 	}
 	
 	public static Impact getByValue(int impactValue) {

--- a/src/main/java/io/github/apace100/origins/origin/Impact.java
+++ b/src/main/java/io/github/apace100/origins/origin/Impact.java
@@ -1,6 +1,6 @@
 package io.github.apace100.origins.origin;
 
-import net.minecraft.text.TranslatableText;
+import net.minecraft.text.TranslatableTextContent;
 import net.minecraft.util.Formatting;
 
 public enum Impact {
@@ -32,7 +32,7 @@ public enum Impact {
 		return textStyle;
 	}
 	
-	public TranslatableText getTextComponent() {
+	public TranslatableTextContent getTextComponent() {
 		return (TranslatableText)new TranslatableText(getTranslationKey()).formatted(getTextStyle());
 	}
 	

--- a/src/main/java/io/github/apace100/origins/origin/Origin.java
+++ b/src/main/java/io/github/apace100/origins/origin/Origin.java
@@ -20,7 +20,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.network.PacketByteBuf;
-import net.minecraft.text.TranslatableText;
+import net.minecraft.text.TranslatableTextContent;
 import net.minecraft.util.Identifier;
 
 import java.util.HashMap;
@@ -186,8 +186,8 @@ public class Origin {
         return nameTranslationKey;
     }
 
-    public TranslatableText getName() {
-        return new TranslatableText(getOrCreateNameTranslationKey());
+    public TranslatableTextContent getName() {
+        return new TranslatableTextContent(getOrCreateNameTranslationKey());
     }
 
     public String getOrCreateDescriptionTranslationKey() {
@@ -198,8 +198,8 @@ public class Origin {
         return descriptionTranslationKey;
     }
 
-    public TranslatableText getDescription() {
-        return new TranslatableText(getOrCreateDescriptionTranslationKey());
+    public TranslatableTextContent getDescription() {
+        return new TranslatableTextContent(getOrCreateDescriptionTranslationKey());
     }
 
     public int getOrder() {

--- a/src/main/java/io/github/apace100/origins/origin/Origin.java
+++ b/src/main/java/io/github/apace100/origins/origin/Origin.java
@@ -186,8 +186,8 @@ public class Origin {
         return nameTranslationKey;
     }
 
-    public TranslatableTextContent getName() {
-        return new TranslatableTextContent(getOrCreateNameTranslationKey());
+    public translatable getName() {
+        return new translatable(getOrCreateNameTranslationKey());
     }
 
     public String getOrCreateDescriptionTranslationKey() {
@@ -198,8 +198,8 @@ public class Origin {
         return descriptionTranslationKey;
     }
 
-    public TranslatableTextContent getDescription() {
-        return new TranslatableTextContent(getOrCreateDescriptionTranslationKey());
+    public translatable getDescription() {
+        return new translatable(getOrCreateDescriptionTranslationKey());
     }
 
     public int getOrder() {

--- a/src/main/java/io/github/apace100/origins/screen/ChooseOriginScreen.java
+++ b/src/main/java/io/github/apace100/origins/screen/ChooseOriginScreen.java
@@ -16,10 +16,10 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.network.PacketByteBuf;
-import net.minecraft.text.LiteralText;
+import net.minecraft.text.LiteralTextContent;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
-import net.minecraft.text.TranslatableText;
+import net.minecraft.text.TranslatableTextContent;
 import net.minecraft.util.Identifier;
 
 import java.util.ArrayList;

--- a/src/main/java/io/github/apace100/origins/screen/ViewOriginScreen.java
+++ b/src/main/java/io/github/apace100/origins/screen/ViewOriginScreen.java
@@ -12,9 +12,9 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
-import net.minecraft.text.LiteralText;
+import net.minecraft.text.LiteralTextContent;
 import net.minecraft.text.Text;
-import net.minecraft.text.TranslatableText;
+import net.minecraft.text.TranslatableTextContent;
 import net.minecraft.util.Pair;
 
 import java.util.ArrayList;

--- a/src/main/java/io/github/apace100/origins/screen/WaitForNextLayerScreen.java
+++ b/src/main/java/io/github/apace100/origins/screen/WaitForNextLayerScreen.java
@@ -7,7 +7,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.text.LiteralText;
+import net.minecraft.text.LiteralTextContent;
 
 import java.util.ArrayList;
 


### PR DESCRIPTION
I was able to manage to fix most of the code for it to port to 22w16b but at least I managed to cut off some time for you so you wouldn't be stressed as much

--------------------------------------------------
> Configure project :
Fabric Loom: 0.11.34
Loom is applying dependency data manually to publications instead of using a software component (from(components["java"])). This is deprecated and will be removed in Loom 0.12.
Not publishing sources jar as it was not found. Use java.withSourcesJar() to fix.

> Task :compileJava
warning: unknown enum constant Env.CLIENT
  reason: class file for com.demonwav.mcdev.annotations.Env not found
warning: unknown enum constant Env.CLIENT
C:\Users\ruthie51749yahoo.com\origins-fabric-22w16b-1.19\src\main\java\io\github\apace100\origins\origin\Origin.java:189: error: cannot find symbol
    public translatable getName() {
           ^
  symbol:   class translatable
  location: class Origin
C:\Users\ruthie51749yahoo.com\origins-fabric-22w16b-1.19\src\main\java\io\github\apace100\origins\origin\Origin.java:201: error: cannot find symbol
    public translatable getDescription() {
           ^
  symbol:   class translatable
  location: class Origin
C:\Users\ruthie51749yahoo.com\origins-fabric-22w16b-1.19\src\main\java\io\github\apace100\origins\origin\Impact.java:35: error: cannot find symbol
        public translatable getTextComponent() {
               ^
  symbol:   class translatable
  location: class Impact
warning: unknown enum constant Env.CLIENT
  reason: class file for com.demonwav.mcdev.annotations.Env not found
3 errors
3 warnings