### PR TITLE
Made it easier for addon devs and others to get when a player changes its origin

### DIFF
--- a/src/main/java/io/github/apace100/origins/event/PlayerOriginUpdateEvent.java
+++ b/src/main/java/io/github/apace100/origins/event/PlayerOriginUpdateEvent.java
@@ -1,0 +1,68 @@
+package io.github.apace100.origins.event;
+
+import io.github.apace100.origins.origin.Origin;
+import io.github.apace100.origins.origin.OriginRegistry;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.LinkedList;
+import java.util.function.Consumer;
+
+/**
+ * This event is getting called whenever the origin of a player changes
+ */
+public class PlayerOriginUpdateEvent {
+    private static final LinkedList<Consumer<PlayerOriginUpdateEvent>> LISTENERS = new LinkedList<>();
+
+    private final @NotNull ServerPlayerEntity player;
+    private final @NotNull Origin origin;
+
+    /**
+     * This is only the data transmitter for this event.
+     * Only usage is for the {@link PlayerOriginUpdateEvent#emit(PlayerOriginUpdateEvent)}
+     *
+     * @param player   The player that changed its origin
+     * @param originId The origin id of the origin
+     */
+    public PlayerOriginUpdateEvent(@NotNull ServerPlayerEntity player, @NotNull String originId) {
+        this.player = player;
+        this.origin = OriginRegistry.get(new Identifier(originId));
+    }
+
+    /**
+     * Call every registered listener for this event
+     *
+     * @param event The event that is being emitted.
+     */
+    public static void emit(@NotNull PlayerOriginUpdateEvent event) {
+        LISTENERS.forEach(listener -> listener.accept(event));
+    }
+
+    /**
+     * Add a listener for this event
+     *
+     * @param listener The listener to subscribe to the event.
+     */
+    public static void subscribe(@NotNull Consumer<PlayerOriginUpdateEvent> listener) {
+        LISTENERS.add(listener);
+    }
+
+    /**
+     * Gives you the player of the event
+     *
+     * @return The player that changed its origin.
+     */
+    public @NotNull ServerPlayerEntity getPlayer() {
+        return player;
+    }
+
+    /**
+     * Gives you the origin of the event
+     *
+     * @return The origin of the player.
+     */
+    public @NotNull Origin getOrigin() {
+        return origin;
+    }
+}

--- a/src/main/java/io/github/apace100/origins/networking/ModPacketsC2S.java
+++ b/src/main/java/io/github/apace100/origins/networking/ModPacketsC2S.java
@@ -2,6 +2,7 @@ package io.github.apace100.origins.networking;
 
 import io.github.apace100.origins.Origins;
 import io.github.apace100.origins.component.OriginComponent;
+import io.github.apace100.origins.event.PlayerOriginUpdateEvent;
 import io.github.apace100.origins.origin.Origin;
 import io.github.apace100.origins.origin.OriginLayer;
 import io.github.apace100.origins.origin.OriginLayers;
@@ -51,6 +52,7 @@ public class ModPacketsC2S {
                             OriginComponent.onChosen(playerEntity, hadOriginBefore);
                         }
                         Origins.LOGGER.info("Player " + playerEntity.getDisplayName().asString() + " chose Origin: " + originId + ", for layer: " + layerId);
+                        PlayerOriginUpdateEvent.emit(new PlayerOriginUpdateEvent(playerEntity, originId));
                     } else {
                         Origins.LOGGER.info("Player " + playerEntity.getDisplayName().asString() + " tried to choose unchoosable Origin for layer " + layerId + ": " + originId + ".");
                         component.setOrigin(layer, Origin.EMPTY);


### PR DESCRIPTION
Added a event that gets emitted when a player updates it's origin.
It allows for an easy-to-use api bind, where you don't have to deal with mixins.

Tested it for client and server with the excat codes I posted down below.

## How to use it:

Listener.java:
```java

import io.github.apace100.origins.event.PlayerOriginUpdateEvent;
import org.jetbrains.annotations.NotNull;

public class Listener {

    public void register() {
        PlayerOriginUpdateEvent.subscribe(this::updateOrigin);
    }

    private void updateOrigin(@NotNull PlayerOriginUpdateEvent event) {
        System.out.println("Received origin update event"); // Don't use this. Use Logger#info(message) instead
    }
}

```

ModInitializer#onInitialize():
```java
@Override
public void onInitialize() {
	new Listener().register();
}
```