### PR TITLE
Update Apoli to 2.7.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,14 +7,14 @@ org.gradle.jvmargs=-Xmx4G
 	loader_version=0.14.12
 
 # Mod Properties
-	mod_version = 1.8.0
+	mod_version = 1.8.1
 	maven_group = com.github.apace100
 	archives_base_name = Origins-1.19.3
 
 # Dependencies
 	fabric_version=0.72.0+1.19.3
 	cca_version=5.0.1
-	apoli_version=2.7.0
+	apoli_version=2.7.1
 	reach_version=2.3.1
 	clothconfig_version=9.0.93
 	modmenu_version=5.0.2

--- a/src/main/java/io/github/apace100/origins/Origins.java
+++ b/src/main/java/io/github/apace100/origins/Origins.java
@@ -28,8 +28,10 @@ import me.shedaniel.autoconfig.annotation.Config;
 import me.shedaniel.autoconfig.serializer.ConfigSerializer;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.item.ItemGroups;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.JsonHelper;
@@ -89,6 +91,10 @@ public class Origins implements ModInitializer, OrderedResourceListenerInitializ
 		CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
 			OriginCommand.register(dispatcher);
 		});
+		ItemGroupEvents.modifyEntriesEvent(ItemGroups.TOOLS).register((content) -> {
+			content.add(ModItems.ORB_OF_ORIGIN);
+		});
+
 		CriteriaRegistryInvoker.callRegister(ChoseOriginCriterion.INSTANCE);
 	}
 


### PR DESCRIPTION
Updated Apoli to 2.7.1.

Fixed Orb of Origin missing in creative inventory.

Bumped version to 1.8.1.