### PR TITLE
Improve modded food compatibility

### DIFF
--- a/src/main/resources/data/origins/tags/items/meat.json
+++ b/src/main/resources/data/origins/tags/items/meat.json
@@ -19,6 +19,14 @@
     "minecraft:cooked_beef",
     "minecraft:cooked_mutton",
     "minecraft:cooked_salmon",
-    "minecraft:spider_eye"
+    "minecraft:spider_eye",
+    {
+      "id": "#c:raw_meat",
+      "required": false
+    },
+    {
+      "id": "#c:cooked_meat",
+      "required": false
+    }
   ]
 }


### PR DESCRIPTION
I added the common tags `c:raw_meat` and `c:cooked_meat` to the `origins:meat` tag. This allows mods that implement those to have automatic support for origins that use the meat tag.