### PR TITLE
Config to disable water protection spawning

### DIFF
--- a/src/main/java/io/github/apace100/origins/Origins.java
+++ b/src/main/java/io/github/apace100/origins/Origins.java
@@ -131,6 +131,8 @@ public class Origins implements ModInitializer, OrderedResourceListenerInitializ
 
 		public boolean performVersionCheck = true;
 
+		public boolean enableWaterProtectionEnchantment = true;
+
 		public JsonObject origins = new JsonObject();
 
 		public boolean isOriginDisabled(Identifier originId) {

--- a/src/main/java/io/github/apace100/origins/mixin/EnchantmentHelperMixin.java
+++ b/src/main/java/io/github/apace100/origins/mixin/EnchantmentHelperMixin.java
@@ -1,0 +1,24 @@
+package io.github.apace100.origins.mixin;
+
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.enchantment.WaterProtectionEnchantment;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.enchantment.EnchantmentLevelEntry;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
+
+@Mixin(EnchantmentHelper.class)
+public class EnchantmentHelperMixin {
+	@Inject(at=@At("RETURN"), method="getPossibleEntries")
+	private static void getPossibleEntries(int power, ItemStack stack, boolean treasureAllowed, CallbackInfoReturnable<List<EnchantmentLevelEntry>> ci) {
+		if (!Origins.config.enableWaterProtectionEnchantment) {
+			ci.getReturnValue().removeIf(ele -> ele != null && ele.enchantment instanceof WaterProtectionEnchantment);
+		}
+	}
+
+}

--- a/src/main/java/io/github/apace100/origins/registry/ModLoot.java
+++ b/src/main/java/io/github/apace100/origins/registry/ModLoot.java
@@ -44,46 +44,46 @@ public class ModLoot {
             if (DUNGEON_LOOT.equals(identifier)) {
                 LootPool.Builder lootPool = new LootPool.Builder();
                 lootPool.rolls(ConstantLootNumberProvider.create(1))
-                        .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                                .weight(20)
-                                .apply(SetNbtLootFunction.builder(waterProtectionLevel1)))
-                        .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                                .weight(10)
-                                .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
-                        .with(EmptyEntry.builder().weight(80));
+                    .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
+                            .weight(20)
+                            .apply(SetNbtLootFunction.builder(waterProtectionLevel1)))
+                    .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
+                            .weight(10)
+                            .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
+                    .with(EmptyEntry.builder().weight(80));
                 tableBuilder.pool(lootPool);
             } else if (STRONGHOLD_LIBRARY.equals(identifier)) {
                 LootPool.Builder lootPool = new LootPool.Builder();
                 lootPool.rolls(ConstantLootNumberProvider.create(1))
-                        .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                                .weight(20)
-                                .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
-                        .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                                .weight(10)
-                                .apply(SetNbtLootFunction.builder(waterProtectionLevel3)))
-                        .with(EmptyEntry.builder().weight(80));
+                    .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
+                            .weight(20)
+                            .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
+                    .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
+                            .weight(10)
+                            .apply(SetNbtLootFunction.builder(waterProtectionLevel3)))
+                    .with(EmptyEntry.builder().weight(80));
                 tableBuilder.pool(lootPool);
             } else if (MINESHAFT.equals(identifier)) {
                 LootPool.Builder lootPool = new LootPool.Builder();
                 lootPool.rolls(ConstantLootNumberProvider.create(1))
-                        .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                                .weight(20)
-                                .apply(SetNbtLootFunction.builder(waterProtectionLevel1)))
-                        .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                                .weight(5)
-                                .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
-                        .with(EmptyEntry.builder().weight(90));
+                    .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
+                            .weight(20)
+                            .apply(SetNbtLootFunction.builder(waterProtectionLevel1)))
+                    .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
+                            .weight(5)
+                            .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
+                    .with(EmptyEntry.builder().weight(90));
                 tableBuilder.pool(lootPool);
             } else if (WATER_RUIN.equals(identifier)) {
                 LootPool.Builder lootPool = new LootPool.Builder();
                 lootPool.rolls(ConstantLootNumberProvider.create(1))
-                        .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                                .weight(10)
-                                .apply(SetNbtLootFunction.builder(waterProtectionLevel1)))
-                        .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                                .weight(20)
-                                .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
-                        .with(EmptyEntry.builder().weight(110));
+                    .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
+                            .weight(10)
+                            .apply(SetNbtLootFunction.builder(waterProtectionLevel1)))
+                    .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
+                            .weight(20)
+                            .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
+                    .with(EmptyEntry.builder().weight(110));
                 tableBuilder.pool(lootPool);
             }
         }));

--- a/src/main/java/io/github/apace100/origins/registry/ModLoot.java
+++ b/src/main/java/io/github/apace100/origins/registry/ModLoot.java
@@ -38,52 +38,52 @@ public class ModLoot {
         NbtCompound waterProtectionLevel2 = createEnchantmentTag(ModEnchantments.WATER_PROTECTION, 2);
         NbtCompound waterProtectionLevel3 = createEnchantmentTag(ModEnchantments.WATER_PROTECTION, 3);
         LootTableEvents.MODIFY.register(((resourceManager, lootManager, identifier, tableBuilder, source) -> {
-            if (!source.isBuiltin()) {
+            if (Origins.config.enableWaterProtectionEnchantment || !source.isBuiltin()) {
                 return;
             }
             if (DUNGEON_LOOT.equals(identifier)) {
                 LootPool.Builder lootPool = new LootPool.Builder();
                 lootPool.rolls(ConstantLootNumberProvider.create(1))
-                    .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                        .weight(20)
-                        .apply(SetNbtLootFunction.builder(waterProtectionLevel1)))
-                    .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                        .weight(10)
-                        .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
-                    .with(EmptyEntry.builder().weight(80));
+                        .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
+                                .weight(20)
+                                .apply(SetNbtLootFunction.builder(waterProtectionLevel1)))
+                        .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
+                                .weight(10)
+                                .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
+                        .with(EmptyEntry.builder().weight(80));
                 tableBuilder.pool(lootPool);
             } else if (STRONGHOLD_LIBRARY.equals(identifier)) {
                 LootPool.Builder lootPool = new LootPool.Builder();
                 lootPool.rolls(ConstantLootNumberProvider.create(1))
-                    .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                        .weight(20)
-                        .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
-                    .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                        .weight(10)
-                        .apply(SetNbtLootFunction.builder(waterProtectionLevel3)))
-                    .with(EmptyEntry.builder().weight(80));
+                        .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
+                                .weight(20)
+                                .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
+                        .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
+                                .weight(10)
+                                .apply(SetNbtLootFunction.builder(waterProtectionLevel3)))
+                        .with(EmptyEntry.builder().weight(80));
                 tableBuilder.pool(lootPool);
             } else if (MINESHAFT.equals(identifier)) {
                 LootPool.Builder lootPool = new LootPool.Builder();
                 lootPool.rolls(ConstantLootNumberProvider.create(1))
-                    .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                        .weight(20)
-                        .apply(SetNbtLootFunction.builder(waterProtectionLevel1)))
-                    .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                        .weight(5)
-                        .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
-                    .with(EmptyEntry.builder().weight(90));
+                        .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
+                                .weight(20)
+                                .apply(SetNbtLootFunction.builder(waterProtectionLevel1)))
+                        .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
+                                .weight(5)
+                                .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
+                        .with(EmptyEntry.builder().weight(90));
                 tableBuilder.pool(lootPool);
             } else if (WATER_RUIN.equals(identifier)) {
                 LootPool.Builder lootPool = new LootPool.Builder();
                 lootPool.rolls(ConstantLootNumberProvider.create(1))
-                    .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                        .weight(10)
-                        .apply(SetNbtLootFunction.builder(waterProtectionLevel1)))
-                    .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                        .weight(20)
-                        .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
-                    .with(EmptyEntry.builder().weight(110));
+                        .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
+                                .weight(10)
+                                .apply(SetNbtLootFunction.builder(waterProtectionLevel1)))
+                        .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
+                                .weight(20)
+                                .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
+                        .with(EmptyEntry.builder().weight(110));
                 tableBuilder.pool(lootPool);
             }
         }));

--- a/src/main/java/io/github/apace100/origins/registry/ModLoot.java
+++ b/src/main/java/io/github/apace100/origins/registry/ModLoot.java
@@ -45,44 +45,44 @@ public class ModLoot {
                 LootPool.Builder lootPool = new LootPool.Builder();
                 lootPool.rolls(ConstantLootNumberProvider.create(1))
                     .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                            .weight(20)
-                            .apply(SetNbtLootFunction.builder(waterProtectionLevel1)))
+                        .weight(20)
+                        .apply(SetNbtLootFunction.builder(waterProtectionLevel1)))
                     .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                            .weight(10)
-                            .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
+                        .weight(10)
+                        .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
                     .with(EmptyEntry.builder().weight(80));
                 tableBuilder.pool(lootPool);
             } else if (STRONGHOLD_LIBRARY.equals(identifier)) {
                 LootPool.Builder lootPool = new LootPool.Builder();
                 lootPool.rolls(ConstantLootNumberProvider.create(1))
                     .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                            .weight(20)
-                            .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
+                        .weight(20)
+                        .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
                     .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                            .weight(10)
-                            .apply(SetNbtLootFunction.builder(waterProtectionLevel3)))
+                        .weight(10)
+                        .apply(SetNbtLootFunction.builder(waterProtectionLevel3)))
                     .with(EmptyEntry.builder().weight(80));
                 tableBuilder.pool(lootPool);
             } else if (MINESHAFT.equals(identifier)) {
                 LootPool.Builder lootPool = new LootPool.Builder();
                 lootPool.rolls(ConstantLootNumberProvider.create(1))
                     .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                            .weight(20)
-                            .apply(SetNbtLootFunction.builder(waterProtectionLevel1)))
+                        .weight(20)
+                        .apply(SetNbtLootFunction.builder(waterProtectionLevel1)))
                     .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                            .weight(5)
-                            .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
+                        .weight(5)
+                        .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
                     .with(EmptyEntry.builder().weight(90));
                 tableBuilder.pool(lootPool);
             } else if (WATER_RUIN.equals(identifier)) {
                 LootPool.Builder lootPool = new LootPool.Builder();
                 lootPool.rolls(ConstantLootNumberProvider.create(1))
                     .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                            .weight(10)
-                            .apply(SetNbtLootFunction.builder(waterProtectionLevel1)))
+                        .weight(10)
+                        .apply(SetNbtLootFunction.builder(waterProtectionLevel1)))
                     .with(ItemEntry.builder(Items.ENCHANTED_BOOK)
-                            .weight(20)
-                            .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
+                        .weight(20)
+                        .apply(SetNbtLootFunction.builder(waterProtectionLevel2)))
                     .with(EmptyEntry.builder().weight(110));
                 tableBuilder.pool(lootPool);
             }

--- a/src/main/resources/origins.mixins.json
+++ b/src/main/resources/origins.mixins.json
@@ -6,6 +6,7 @@
   "mixins": [
     "ArgumentTypesMixin",
     "ConduitOnLandMixin",
+    "EnchantmentHelperMixin",
     "LikeWaterMixin",
     "LoginMixin",
     "NoCobwebSlowdownMixin",


### PR DESCRIPTION
This is just a simple addition of a configuration option that, when disabled, prevents water protection books from being added to loot tables, prevents water protection from being rolled at an enchanting table, and prevents water protection from being rolled on enchanted treasure gear.


It doesn't actually de-register the enchantment, just prevents it from appearing in the game naturally.

Credit - the mixin is based on [Yttr](https://git.sleeping.town/unascribed-mods/Yttr/src/branch/1.19.2/src/main/java/com/unascribed/yttr/mixin/coil/MixinEnchantmentHelper.java)

The reasoning behind this addition is that it's very easy to create a datapack or modpack that doesn't include hydrophobic damage whatsoever - but before this point it's not so easy to remove the (in that case useless) enchantment from table chances and random loot.

If for whatever reason you'd prefer water protection to be a pure book-treasure enchantment regardless of the config option, I'm happy to remove the config guard in the mixin!