### PR TITLE
Switch ladysnake maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ group = project.maven_group
 repositories {
 	maven {
 		name = "Ladysnake Libs"
-		url = 'https://ladysnake.jfrog.io/artifactory/mods'
+		url = 'https://maven.ladysnake.org/releases'
 	}
 	maven {
 		url = 'https://maven.cafeteria.dev'


### PR DESCRIPTION
Ladysnake is switching maven links on 1st of July, this is to avoid dependency issues