### PR TITLE
Configurable Water Protection

### DIFF
--- a/src/main/java/io/github/apace100/origins/Origins.java
+++ b/src/main/java/io/github/apace100/origins/Origins.java
@@ -1,5 +1,6 @@
 package io.github.apace100.origins;
 
+import blue.endless.jankson.Comment;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
@@ -25,6 +26,7 @@ import io.github.apace100.origins.util.OriginsJsonConfigSerializer;
 import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
+import me.shedaniel.autoconfig.annotation.ConfigEntry;
 import me.shedaniel.autoconfig.serializer.ConfigSerializer;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
@@ -134,6 +136,20 @@ public class Origins implements ModInitializer, OrderedResourceListenerInitializ
 	public static class ServerConfig implements ConfigData {
 
 		public boolean performVersionCheck = true;
+
+		@ConfigEntry.Gui.CollapsibleObject
+		public WaterProtection waterProtection = new WaterProtection();
+
+		public static class WaterProtection {
+			@Comment("Warning! Changing this may prevent you from joining origins servers. Do so at your own risk!")
+			public boolean register = true;
+
+			public boolean enchantingTable = false;
+
+			public boolean treasureBooks = true;
+
+			public boolean treasureOther = false;
+		}
 
 		public JsonObject origins = new JsonObject();
 

--- a/src/main/java/io/github/apace100/origins/mixin/EnchantmentHelperMixin.java
+++ b/src/main/java/io/github/apace100/origins/mixin/EnchantmentHelperMixin.java
@@ -1,0 +1,24 @@
+package io.github.apace100.origins.mixin;
+
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.enchantment.WaterProtectionEnchantment;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.enchantment.EnchantmentLevelEntry;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
+
+@Mixin(EnchantmentHelper.class)
+public class EnchantmentHelperMixin {
+    @Inject(at=@At("RETURN"), method="getPossibleEntries")
+    private static void getPossibleEntries(int power, ItemStack stack, boolean treasureAllowed, CallbackInfoReturnable<List<EnchantmentLevelEntry>> ci) {
+        if ((!treasureAllowed && !Origins.config.waterProtection.enchantingTable) || (treasureAllowed && !Origins.config.waterProtection.treasureOther)) {
+            ci.getReturnValue().removeIf(ele -> ele != null && ele.enchantment instanceof WaterProtectionEnchantment);
+        }
+    }
+
+}

--- a/src/main/java/io/github/apace100/origins/registry/ModEnchantments.java
+++ b/src/main/java/io/github/apace100/origins/registry/ModEnchantments.java
@@ -8,13 +8,14 @@ import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.registry.Registries;
 import net.minecraft.util.Identifier;
 import net.minecraft.registry.Registry;
+import org.jetbrains.annotations.Nullable;
 
 public class ModEnchantments {
 
-    public static final Enchantment WATER_PROTECTION = new WaterProtectionEnchantment(Enchantment.Rarity.RARE, EnchantmentTarget.ARMOR, new EquipmentSlot[]{EquipmentSlot.HEAD, EquipmentSlot.CHEST, EquipmentSlot.LEGS, EquipmentSlot.FEET});
+    public static final @Nullable Enchantment WATER_PROTECTION = Origins.config.waterProtection.register ? new WaterProtectionEnchantment(Enchantment.Rarity.RARE, EnchantmentTarget.ARMOR, new EquipmentSlot[]{EquipmentSlot.HEAD, EquipmentSlot.CHEST, EquipmentSlot.LEGS, EquipmentSlot.FEET}) : null;
 
     public static void register() {
-        register("water_protection", WATER_PROTECTION);
+        if (WATER_PROTECTION != null) register("water_protection", WATER_PROTECTION);
     }
 
     private static Enchantment register(String path, Enchantment enchantment) {

--- a/src/main/java/io/github/apace100/origins/registry/ModLoot.java
+++ b/src/main/java/io/github/apace100/origins/registry/ModLoot.java
@@ -1,5 +1,6 @@
 package io.github.apace100.origins.registry;
 
+import io.github.apace100.origins.Origins;
 import net.fabricmc.fabric.api.loot.v2.LootTableEvents;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentLevelEntry;
@@ -21,11 +22,12 @@ public class ModLoot {
     private static final Identifier WATER_RUIN = new Identifier("minecraft", "chests/underwater_ruin_small");
 
     public static void registerLootTables() {
+        if (ModEnchantments.WATER_PROTECTION == null) return;
         NbtCompound waterProtectionLevel1 = createEnchantmentTag(ModEnchantments.WATER_PROTECTION, 1);
         NbtCompound waterProtectionLevel2 = createEnchantmentTag(ModEnchantments.WATER_PROTECTION, 2);
         NbtCompound waterProtectionLevel3 = createEnchantmentTag(ModEnchantments.WATER_PROTECTION, 3);
         LootTableEvents.MODIFY.register(((resourceManager, lootManager, identifier, tableBuilder, source) -> {
-            if (!source.isBuiltin()) {
+            if (!Origins.config.waterProtection.treasureBooks || source.isBuiltin()) {
                 return;
             }
             if (DUNGEON_LOOT.equals(identifier)) {

--- a/src/main/resources/origins.mixins.json
+++ b/src/main/resources/origins.mixins.json
@@ -6,6 +6,7 @@
     "mixins": [
         "ArgumentTypesMixin",
         "ConduitOnLandMixin",
+        "EnchantmentHelperMixin",
         "LikeWaterMixin",
         "NoCobwebSlowdownMixin",
         "OriginUpgradeMixin",


### PR DESCRIPTION
Let's try this one more time!

This PR adds a new block to `origins_server.json` that allows individual toggling of water protection appearing in the enchanting table, on treasure books, and on treasure gear. 

By default, water protection only appears on treasure books - this prevents origins from changing game balance even when human is selected (by reducing the odds to get useful enchantments at the table and on loot gear)

It also adds an option to disable the registration of the water protection enchantment entirely - this is a utility option for modpackers that don't use the `water_vulnerability` power at all, intended to allow them to ensure that water protection is completely unobtainable - and doesn't appear in recipe viewers or the creative screen.
If toggled by an unaware user, this option will naturally prevent them from joining origins servers due to the registry mismatch, and could potentially cause a crash via an origins addon (though a nullable annotation was added to prevent this into the future) - however, I think the tradeoffs are worth it in this case.