### PR TITLE
Add power for resetting phantomize state upon death.

### DIFF
--- a/src/main/resources/data/origins/origins/phantom.json
+++ b/src/main/resources/data/origins/origins/phantom.json
@@ -7,7 +7,8 @@
 		"origins:burn_in_daylight",
 		"origins:hunger_over_time",
 		"origins:fragile",
-		"origins:phantomize_overlay"
+		"origins:phantomize_overlay",
+		"origins:phantomize_callback"
 	],
 	"icon": {
 		"item": "minecraft:phantom_membrane"

--- a/src/main/resources/data/origins/powers/phantomize_callback.json
+++ b/src/main/resources/data/origins/powers/phantomize_callback.json
@@ -1,0 +1,16 @@
+{
+  "type": "origins:action_on_callback",
+  "entity_action_respawned": {
+    "type": "origins:if_else",
+    "condition": {
+      "type": "origins:power_active",
+      "power": "origins:phantomize",
+      "inverted": true
+    },
+    "if_action": {
+      "type": "origins:toggle",
+      "power": "origins:phantomize"
+    }
+  },
+  "hidden": true
+}


### PR DESCRIPTION
You usually don't want to burn upon spawning back in. This is primarily a QoL/fix feature.