### PR TITLE
Add `fabric:load_conditions` compatibility to Origins data loaders.

### DIFF
--- a/src/main/java/io/github/apace100/origins/origin/OriginLayers.java
+++ b/src/main/java/io/github/apace100/origins/origin/OriginLayers.java
@@ -3,7 +3,9 @@ package io.github.apace100.origins.origin;
 import carpet.patches.EntityPlayerMPFake;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
 import dev.onyxstudios.cca.api.v3.component.ComponentProvider;
+import io.github.apace100.apoli.util.ApoliResourceConditions;
 import io.github.apace100.calio.data.IdentifiableMultiJsonDataLoader;
 import io.github.apace100.calio.data.MultiJsonDataContainer;
 import io.github.apace100.calio.data.SerializableData;
@@ -182,6 +184,10 @@ public class OriginLayers extends IdentifiableMultiJsonDataLoader implements Ide
 
                 Origins.LOGGER.info("Trying to read origin layer file \"{}\" from data pack [{}]", id, packName);
 
+                if (!isResourceConditionValid(id, jsonElement.getAsJsonObject())) {
+                    return;
+                }
+
                 OriginLayer layer = OriginLayer.fromJson(id, jsonElement.getAsJsonObject());
                 int loadingPriority = layer.getLoadingPriority();
 
@@ -189,6 +195,8 @@ public class OriginLayers extends IdentifiableMultiJsonDataLoader implements Ide
                     Origins.LOGGER.warn("Ignoring replaced duplicate origin layer \"{}\" with a lower loading priority.", id);
                     return;
                 }
+
+                layer.getConditionedOrigins().forEach(co -> co.origins().removeIf(OriginRegistry::isDisabled));
 
                 List<String> invalidOrigins = layer.getConditionedOrigins()
                     .stream()
@@ -302,6 +310,10 @@ public class OriginLayers extends IdentifiableMultiJsonDataLoader implements Ide
 
     public static void clear() {
         LAYERS.clear();
+    }
+
+    private boolean isResourceConditionValid(Identifier id, JsonObject jo) {
+        return ApoliResourceConditions.test(id, jo);
     }
 
     @Override

--- a/src/main/java/io/github/apace100/origins/origin/OriginManager.java
+++ b/src/main/java/io/github/apace100/origins/origin/OriginManager.java
@@ -2,8 +2,10 @@ package io.github.apace100.origins.origin;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
 import io.github.apace100.apoli.Apoli;
 import io.github.apace100.apoli.power.PowerTypes;
+import io.github.apace100.apoli.util.ApoliResourceConditions;
 import io.github.apace100.calio.data.IdentifiableMultiJsonDataLoader;
 import io.github.apace100.calio.data.MultiJsonDataContainer;
 import io.github.apace100.calio.data.SerializableData;
@@ -46,6 +48,13 @@ public class OriginManager extends IdentifiableMultiJsonDataLoader implements Id
 				SerializableData.CURRENT_NAMESPACE = id.getNamespace();
 				SerializableData.CURRENT_PATH = id.getPath();
 
+				if (!isResourceConditionValid(id, jsonElement.getAsJsonObject())) {
+					if (!OriginRegistry.contains(id)) {
+						OriginRegistry.disable(id);
+					}
+					return;
+				}
+
 				Origin origin = Origin.fromJson(id, jsonElement.getAsJsonObject());
 				int loadingPriority = origin.getLoadingPriority();
 
@@ -86,6 +95,10 @@ public class OriginManager extends IdentifiableMultiJsonDataLoader implements Id
 		SerializableData.CURRENT_NAMESPACE = null;
 		SerializableData.CURRENT_PATH = null;
 
+	}
+
+	private boolean isResourceConditionValid(Identifier id, JsonObject jo) {
+		return ApoliResourceConditions.test(id, jo);
 	}
 
 	@Override

--- a/src/main/java/io/github/apace100/origins/origin/OriginRegistry.java
+++ b/src/main/java/io/github/apace100/origins/origin/OriginRegistry.java
@@ -8,12 +8,14 @@ import net.minecraft.util.Identifier;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
 public class OriginRegistry {
 
     private static final Map<Identifier, Origin> idToOrigin = new HashMap<>();
+    private static final Set<Identifier> disabledOrigins = new HashSet<>();
 
     public static Origin register(Origin origin) {
         return register(origin.getIdentifier(), origin);
@@ -33,6 +35,15 @@ public class OriginRegistry {
     protected static Origin update(Identifier id, Origin origin) {
         idToOrigin.remove(id);
         return register(id, origin);
+    }
+
+    protected static void disable(Identifier id) {
+        remove(id);
+        disabledOrigins.add(id);
+    }
+
+    public static boolean isDisabled(Identifier id) {
+        return disabledOrigins.contains(id);
     }
 
     public static int size() {


### PR DESCRIPTION
Resolves #727 

Adds `fabric:load_conditions` compatibility to Origins' data loaders. Meaning that Origins and Origin Layers both support this field now.

There is no way to check for if a layer is totally disabled, as I did not set up a set for it, seeing that it might be totally unnecessary.