### PR TITLE
Fix Origins powers unable to be disabled via config

### DIFF
--- a/src/main/java/io/github/apace100/origins/origin/Origin.java
+++ b/src/main/java/io/github/apace100/origins/origin/Origin.java
@@ -165,6 +165,9 @@ public class Origin implements Validatable {
 
         this.powers.clear();
         for (PowerReference powerReference : powerReferences) {
+            if (Origins.config.isPowerDisabled(this.id, powerReference.id())) {
+                continue;
+            }
 
             try {
                 powers.add(powerReference.getPower());


### PR DESCRIPTION
Closes #794.
The commit d11d1a6b94a4a8459b95aea0916cea0fcb57262d seems to have caused this issue in its refactor.