### PR TITLE
[1.21.x] Update for Apoli alpha 16

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ org.gradle.parallel=true
 
 # Dependencies
 	fabric_version=0.105.0+1.21.1
-	apoli_version=2.12.0-alpha.15+mc.1.21.1
+	apoli_version=2.12.0-alpha.16+mc.1.21.1
 	clothconfig_version=13.0.121
 	modmenu_version=9.0.0
 	carpet_version=1.21-1.4.147+v240613

--- a/src/main/java/io/github/apace100/origins/badge/BadgeManager.java
+++ b/src/main/java/io/github/apace100/origins/badge/BadgeManager.java
@@ -178,7 +178,7 @@ public final class BadgeManager {
 
     private static void createAutoBadges(Identifier powerId, Power power, List<Badge> badgeList) {
 
-        switch (power.getPowerType()) {
+        switch (power.getType()) {
             case Active active -> {
 
                 boolean toggle = active instanceof TogglePowerType

--- a/src/main/java/io/github/apace100/origins/command/argument/OriginArgumentType.java
+++ b/src/main/java/io/github/apace100/origins/command/argument/OriginArgumentType.java
@@ -42,7 +42,7 @@ public class OriginArgumentType implements ArgumentType<Identifier> {
 
       try {
 
-         OriginLayer layer = context.getArgument("layer", OriginLayer.class);
+         OriginLayer layer = OriginLayerArgumentType.getLayer(context, "layer");
          Stream.Builder<Identifier> origins = Stream.builder();
 
          origins.add(Origin.EMPTY.getId());

--- a/src/main/java/io/github/apace100/origins/command/argument/OriginArgumentType.java
+++ b/src/main/java/io/github/apace100/origins/command/argument/OriginArgumentType.java
@@ -9,14 +9,13 @@ import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import io.github.apace100.origins.origin.*;
 import net.minecraft.command.CommandSource;
-import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
-public class OriginArgumentType implements ArgumentType<Origin> {
+public class OriginArgumentType implements ArgumentType<Identifier> {
 
    public static final DynamicCommandExceptionType ORIGIN_NOT_FOUND = new DynamicCommandExceptionType(
        o -> Text.translatable("commands.origin.origin_not_found", o)
@@ -26,16 +25,16 @@ public class OriginArgumentType implements ArgumentType<Origin> {
       return new OriginArgumentType();
    }
 
-   public static Origin getOrigin(CommandContext<ServerCommandSource> context, String argumentName) {
-      return context.getArgument(argumentName, Origin.class);
-   }
-
-   @Override
-   public Origin parse(StringReader reader) throws CommandSyntaxException {
-      Identifier id =  Identifier.fromCommandInputNonEmpty(reader);
+   public static <S> Origin getOrigin(CommandContext<S> context, String argumentName) throws CommandSyntaxException {
+      Identifier id = context.getArgument(argumentName, Identifier.class);
       return OriginManager
           .getOptional(id)
           .orElseThrow(() -> ORIGIN_NOT_FOUND.create(id));
+   }
+
+   @Override
+   public Identifier parse(StringReader reader) throws CommandSyntaxException {
+      return Identifier.fromCommandInputNonEmpty(reader);
    }
 
    @Override

--- a/src/main/java/io/github/apace100/origins/command/argument/OriginLayerArgumentType.java
+++ b/src/main/java/io/github/apace100/origins/command/argument/OriginLayerArgumentType.java
@@ -10,13 +10,12 @@ import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import io.github.apace100.origins.origin.OriginLayer;
 import io.github.apace100.origins.origin.OriginLayerManager;
 import net.minecraft.command.CommandSource;
-import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import java.util.concurrent.CompletableFuture;
 
-public class OriginLayerArgumentType implements ArgumentType<OriginLayer> {
+public class OriginLayerArgumentType implements ArgumentType<Identifier> {
 
    public static final DynamicCommandExceptionType LAYER_NOT_FOUND = new DynamicCommandExceptionType(
        o -> Text.translatable("commands.origin.layer_not_found", o)
@@ -26,16 +25,16 @@ public class OriginLayerArgumentType implements ArgumentType<OriginLayer> {
       return new OriginLayerArgumentType();
    }
 
-   public static OriginLayer getLayer(CommandContext<ServerCommandSource> context, String argumentName) {
-      return context.getArgument(argumentName, OriginLayer.class);
-   }
-
-   @Override
-   public OriginLayer parse(StringReader reader) throws CommandSyntaxException {
-      Identifier id = Identifier.fromCommandInputNonEmpty(reader);
+   public static <S> OriginLayer getLayer(CommandContext<S> context, String argumentName) throws CommandSyntaxException {
+      Identifier id = context.getArgument(argumentName, Identifier.class);
       return OriginLayerManager.getResult(id)
           .result()
           .orElseThrow(() -> LAYER_NOT_FOUND.create(id));
+   }
+
+   @Override
+   public Identifier parse(StringReader reader) throws CommandSyntaxException {
+      return Identifier.fromCommandInputNonEmpty(reader);
    }
 
    @Override

--- a/src/main/java/io/github/apace100/origins/util/PowerKeyManager.java
+++ b/src/main/java/io/github/apace100/origins/util/PowerKeyManager.java
@@ -33,7 +33,7 @@ public class PowerKeyManager {
 
     private static Optional<String> getKeyFromPower(Power power) {
 
-        if (power.getPowerType() instanceof Active activePowerType) {
+        if (power.getType() instanceof Active activePowerType) {
 
             KeyBindingReference keyBindingReference = activePowerType.getKey();
             String keyId = keyBindingReference.id();


### PR DESCRIPTION
Updates Origins to be compatible with the minor refactoring that was done in Apoli 2.12.0-alpha.16 (assuming apace100/apoli@5b3a79aebaa129bff06a153a0feee25cb2dacf53 [`Bumped mod version`] becomes Apoli 2.12.0-alpha.16, like every other [`Bumped mod version`] commit has previously)

Additionally, I have replicated the changes made in apace100/apoli@27e8ce8fe58bcd06b54b98dd202515322005b6b4 [`Fixed mcfunction loading issues with the power argument type`] for the origin and origin layer argument types (fixing #822).

Note: Unfortunately, Apoli 2.12.0-alpha.16 has not received a formal GitHub release as of writing, meaning JitPack cannot find it.  
Because of this, I have made a [mock release](<https://github.com/JoshieGemFinder/origins-fabric-patches/releases/tag/1.13.0-alpha.13%2Bmc.1.21.1>) to showcase the built jars, as this pull request cannot be trivially built until Apoli 2.12.0-alpha.16 receives a GitHub release.

