### PR TITLE
Update JDK version from 17 to 21 to fix 1.21.1 builds

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-  - openjdk17
+  - openjdk21


### PR DESCRIPTION
Jitpack is failing to build for 1.21.x because Minecraft 1.21.1 requires [Java 21 but this project is configured to use Java 17.](https://jitpack.io/com/github/apace100/origins-fabric/d25a05132f24d5845af02e259326a512cb435216/build.log)