### PR TITLE
dont crash when water protection is filtered

### DIFF
--- a/src/main/java/io/github/apace100/origins/registry/ModLoot.java
+++ b/src/main/java/io/github/apace100/origins/registry/ModLoot.java
@@ -48,7 +48,9 @@ public class ModLoot {
 
             RegistryEntry<Enchantment> waterProtection = registries
                 .getWrapperOrThrow(RegistryKeys.ENCHANTMENT)
-                .getOrThrow(ModEnchantments.WATER_PROTECTION);
+                .getOptional(ModEnchantments.WATER_PROTECTION).orElse(null);
+
+            if (waterProtection == null) return;
 
             if (key.equals(SIMPLE_DUNGEON)) {
                 tableBuilder.pool(new LootPool.Builder()


### PR DESCRIPTION
acknowledges the possibility that water protection may not exist in the modpack (i.e, was filtered by a datapack that also removes the origin / modifies the power that uses it)