### PR TITLE
Add implementation version to JAR manifests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,6 +170,12 @@ tasks.register("fabricJar", Jar) {
 	addMarkerToJar(it, "fabric")
 	destinationDirectory.set(file("$buildDir/libs/fabric"))
 	archiveFileName.set(tasks.named("remapJar").get().archiveFileName.get())
+
+	manifest {
+		attributes([
+			"Implementation-Version": project.version
+		])
+	}
 }
 
 tasks.register("forgeJar", Jar) {
@@ -178,6 +184,12 @@ tasks.register("forgeJar", Jar) {
 	addMarkerToJar(it, "forge")
 	destinationDirectory.set(file("$buildDir/libs/forge"))
 	archiveFileName.set(tasks.named("remapJar").get().archiveFileName.get())
+
+	manifest {
+		attributes([
+			"Implementation-Version": project.version
+		])
+	}
 }
 
 tasks.named("build").configure {


### PR DESCRIPTION
Without this, the `mods.toml` doesn't have a mod version assigned, and Forge will assign it to `0.0NONE`, which would cause mods depending on Origins in a Forge mods.toml to erroneously resolve correctly for any version (see: MinecraftForge/MinecraftForge#10696). Additionally, Prism Launcher reads the `mods.toml` first instead of the `fabric.mod.json`, resulting in the version displaying as `NONE` instead of the actual mod version in the launcher.

This affects both the Fabric and Forge JARs, hence why I added it for both. Assigning it to the `jar` task would only work if one runs `remapJar` directly, but it doesn't work if you're running `forgeJar` or `fabricJar` for some reason.